### PR TITLE
Fix check-in validation reply

### DIFF
--- a/src/main/java/io/github/jnicog/discord/spanner/bot/controller/QueueController.java
+++ b/src/main/java/io/github/jnicog/discord/spanner/bot/controller/QueueController.java
@@ -88,7 +88,7 @@ public class QueueController extends ListenerAdapter {
         boolean removed = queue.removePlayer(user, true);
 
         if (!removed) {
-            notificationService.sendReply(event, "You are not currently in the queue!", false);
+            notificationService.sendReply(event, "You are not currently in the queue!", true);
             return;
         }
 

--- a/src/main/java/io/github/jnicog/discord/spanner/bot/service/NotificationServiceImpl.java
+++ b/src/main/java/io/github/jnicog/discord/spanner/bot/service/NotificationServiceImpl.java
@@ -165,7 +165,7 @@ public class NotificationServiceImpl implements NotificationService {
 
     @Override
     public void sendReply(IReplyCallback interactionEvent, String message, boolean isEphemeral) {
-        interactionEvent.deferReply().queue(success -> {
+        interactionEvent.deferReply().setEphemeral(isEphemeral).queue(success -> {
             LOGGER.debug("Successfully deferred reply after interaction");
         }, error -> {
             LOGGER.error("Failed to defer reply after interaction: {}", error.getMessage());


### PR DESCRIPTION
Check-in validation replies are being sent as normal replies instead of ephemeral replies.
.deferReply() being called resulting in a reply to be sent and displayed before the .setEphemeral() is called after alongside the message edit